### PR TITLE
Removed annoying semi column from json method.

### DIFF
--- a/src/Http/ResponseFactory.php
+++ b/src/Http/ResponseFactory.php
@@ -32,7 +32,7 @@ class ResponseFactory
      * @param  int    $status
      * @param  array  $headers
      * @param  int    $options
-     * @return \Illuminate\Http\JsonResponse;
+     * @return \Illuminate\Http\JsonResponse
      */
     public function json($data = [], $status = 200, array $headers = [], $options = 0)
     {


### PR DESCRIPTION
Removed the unnecessary semi column from the documentation. VSCode intelephense complains about it and PHP7 return type feature can't be used because putting semi-column in there is not syntactically correct.

P.S I already removed it locally, and it works like a charm.

Screenshot of mentioned issue: https://ibb.co/zn61dsV